### PR TITLE
Correction of the behavior of the notification's color 

### DIFF
--- a/Growl/lungo.sugar.growl.js
+++ b/Growl/lungo.sugar.growl.js
@@ -153,6 +153,7 @@ LUNGO.Sugar.Growl = (function(lng, undefined) {
     var _hide_children = function() {
         _hide_child(SELECTOR.MODAL);
         _hide_child(SELECTOR.NOTIFY);
+        $(SELECTOR.NOTIFY).attr("class", "notify");
     };
 
     var _hide_child = function(selector) {


### PR DESCRIPTION
Hello TapQuo team,

this pull-request contains a correction for the behavior of the notification's color.

You can see the bug with following code :

LUNGO.Sugar.Growl.notify('Error title', 'Error description', 'flag', 'error', 3);  --> it's in red
LUNGO.Sugar.Growl.notify('Success title', 'Success description', 'flag', 'success', 3); --> it's in green
LUNGO.Sugar.Growl.notify('Error title', 'Error description', 'flag', 'error', 3); --> BUG : it's in green

Regards
